### PR TITLE
Added `directory` to packages git config

### DIFF
--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -3,7 +3,11 @@
   "version": "1.2.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "repository": "git@github.com:rcktpl/packages",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/rcktpl/packages.git",
+    "directory": "packages/cache"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/extractenv/package.json
+++ b/packages/extractenv/package.json
@@ -3,7 +3,11 @@
   "version": "1.0.3",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "repository": "git@github.com:rcktpl/packages",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/rcktpl/packages.git",
+    "directory": "packages/extractEnv"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/zsave/package.json
+++ b/packages/zsave/package.json
@@ -3,7 +3,11 @@
   "version": "1.2.2",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "repository": "git@github.com:rcktpl/packages",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/rcktpl/packages.git",
+    "directory": "packages/zsave"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
### What's been changed?
 - Switched all packages to use `git` object instead of string in `package.json`
 - Added `directory` to all packages `git` config

## Why?
A  niche but little QoL improvement as when NPM adds a repository URL it's better to have it link directly to the package source, not the monorepo root URL.